### PR TITLE
Adds get_perms override to allow report/editor access

### DIFF
--- a/rule_based_perms/models.py
+++ b/rule_based_perms/models.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class RuleConfig(models.Model):
 
     def actions_default(): # default must be a callable for JSONField
-        return ["read"]
+        return ["view_resourceinstance"]
 
     id = models.UUIDField(primary_key=True)
     type = models.CharField(max_length=200)

--- a/rule_based_perms/permissions/arches_filtered_permissions.py
+++ b/rule_based_perms/permissions/arches_filtered_permissions.py
@@ -24,6 +24,7 @@ from arches.app.models.models import ResourceInstance
 from arches.app.search.search import SearchEngine
 import rule_based_perms.permissions.rules as rules
 
+
 class ArchesFilteredPermissionFramework(ArchesDefaultDenyPermissionFramework):
     def __init__(self):
         self.rules = rules.PermissionRules()
@@ -53,7 +54,6 @@ class ArchesFilteredPermissionFramework(ArchesDefaultDenyPermissionFramework):
     def get_perms(
         self, user_or_group: User | Group, obj: ResourceInstance
     ) -> list[str]:
-
 
         filters = {
             "filter_tile_has_value": self.rules.filter_tile_has_value,

--- a/rule_based_perms/permissions/arches_filtered_permissions.py
+++ b/rule_based_perms/permissions/arches_filtered_permissions.py
@@ -54,11 +54,6 @@ class ArchesFilteredPermissionFramework(ArchesDefaultDenyPermissionFramework):
         self, user_or_group: User | Group, obj: ResourceInstance
     ) -> list[str]:
 
-        perm_lookup = {
-            "read": "view_resourceinstance",
-            "edit": "change_resourceinstance",
-            "delete": "delete_resourceinstance",
-            }
 
         filters = {
             "filter_tile_has_value": self.rules.filter_tile_has_value,
@@ -79,5 +74,5 @@ class ArchesFilteredPermissionFramework(ArchesDefaultDenyPermissionFramework):
                     if resources.filter(resourceinstanceid=obj.pk).exists():
                         actions.update(rule_config.actions)
 
-        return [perm_lookup[action] for action in list(actions)]
+        return list(actions)
     

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -74,18 +74,22 @@ class PermissionRules:
     def filter_tile_does_not_have_value(self, filter="db", actions=[], qs=None):
         pass
 
+    def get_config_groups(self, user): 
+        unique_user_groups = set()
+        for rule_config in self.configs:
+            groups = rule_config.groups.all().values_list("name", flat=True)
+            unique_user_groups.update(list(groups))
+
+        return user.groups.filter(name__in=unique_user_groups)
+
     def permission_handler(self, user, actions=["read"], filter="db"):
         print("permission_handler")
         filters = {
             "filter_tile_has_value": self.filter_tile_has_value,
             "filter_tile_does_not_have_value": self.filter_tile_does_not_have_value,
         }
-        unique_user_groups = set()
-        for rule_config in self.configs:
-            groups = rule_config.groups.all().values_list("name", flat=True)
-            unique_user_groups.update(list(groups))
 
-        user_groups = user.groups.filter(name__in=unique_user_groups)
+        user_groups = self.get_config_groups(user)
         res = None
 
         if len(user_groups):

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -82,7 +82,7 @@ class PermissionRules:
 
         return user.groups.filter(name__in=unique_user_groups)
 
-    def permission_handler(self, user, actions=["read"], filter="db"):
+    def permission_handler(self, user, actions=["view_resourceinstance"], filter="db"):
         print("permission_handler")
         filters = {
             "filter_tile_has_value": self.filter_tile_has_value,

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -10,34 +10,7 @@ from arches.app.search.elasticsearch_dsl_builder import Bool, Nested, Terms
 
 
 class PermissionRules:
-    """
-    Leave as example of concept rule config and perm definitions
-    {
-        "type": "filter_tile_has_value",
-        "nodeid": "3faca866-29c7-11ef-ad5f-faffc210b420",
-        "nodegroupid": "5b11ec40-1d2b-11ef-bfd8-faffc210b420",
-        "value": "14a04982-f28c-406b-94ce-2d889769c421",
-        "groups": ["Resource Reviewer"],
-        "actions": ["read"],
-        "name": "Allow access to resources with EIC value",
-    },
 
-    perms = {
-        'elite_group': {
-            'return_confidential_resources': ['read'],
-        }
-        'ohp_group': {
-            'return_ohp_resources': ['read', 'write', 'delete'],
-        },
-        'ndic': {
-            'return_ndic_resources': ['read', 'write', 'delete'],
-            'return_ohp_resources': ['read']
-        },
-        'ohp_intern_group': {
-            'return_ohp_resources_without_confidential': ['read', 'write', 'delete'],
-        },
-    }
-    """
 
     def __init__(self):
         self.configs = RuleConfig.objects.all()

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -11,7 +11,6 @@ from rule_based_perms.models import RuleConfig
 
 class PermissionRules:
 
-
     def __init__(self):
         self.configs = RuleConfig.objects.all()
 

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -56,7 +56,6 @@ class PermissionRules:
         return user.groups.filter(name__in=unique_user_groups)
 
     def permission_handler(self, user, actions=["view_resourceinstance"], filter="db"):
-
         filters = {
             "filter_tile_has_value": self.filter_tile_has_value,
             "filter_tile_does_not_have_value": self.filter_tile_does_not_have_value,

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -47,7 +47,7 @@ class PermissionRules:
     def filter_tile_does_not_have_value(self, filter="db", actions=[], qs=None):
         pass
 
-    def get_config_groups(self, user): 
+    def get_config_groups(self, user: User) -> QuerySet[Group]: 
         unique_user_groups = set()
         for rule_config in self.configs:
             groups = rule_config.groups.all().values_list("name", flat=True)

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -83,7 +83,7 @@ class PermissionRules:
         return user.groups.filter(name__in=unique_user_groups)
 
     def permission_handler(self, user, actions=["view_resourceinstance"], filter="db"):
-        print("permission_handler")
+
         filters = {
             "filter_tile_has_value": self.filter_tile_has_value,
             "filter_tile_does_not_have_value": self.filter_tile_does_not_have_value,

--- a/rule_based_perms/permissions/rules.py
+++ b/rule_based_perms/permissions/rules.py
@@ -1,12 +1,12 @@
-from django.http import HttpRequest
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models import models
+from arches.app.search.elasticsearch_dsl_builder import Bool, Nested
+from django.contrib.auth.models import User, Group
+from django.db.models import Exists, OuterRef, Q
 from django.db.models.fields.json import KT
-from django.db.models import Q
-from django.db.models import Exists, OuterRef
+from django.db.models.query import QuerySet
+from django.http import HttpRequest
 from rule_based_perms.models import RuleConfig
-
-from arches.app.search.elasticsearch_dsl_builder import Bool, Nested, Terms
 
 
 class PermissionRules:


### PR DESCRIPTION
Adds get_perms override to allow permitted users to access the editor and reports. Also changes permission name strings to match those in default deny. To update configs with new strings:

```
update rule_config set actions = '["view_resourceinstance"]';
update rule_config set actions = '["view_resourceinstance", "change_resourceinstance"]' where id = 'baca30f6-96f6-4191-9fa1-f65cb0e3808d';
```